### PR TITLE
Fix height 100% issue with Safari

### DIFF
--- a/server/src/main/assets/stylesheets/main.less
+++ b/server/src/main/assets/stylesheets/main.less
@@ -110,6 +110,7 @@ body {
         > #editor {
           width: 100%;
           height: 100%;
+          position: absolute;
         }
       }
 


### PR DESCRIPTION
Setting position absolute to the flex items child element stretches it´s height to 100% of it´s parent. This will fix the issue with Safari, and does not affect the way Chrome or Firefox works. I did not have a chance to see how Internet Explorer deals with this, but I assume there is no third way to  handle this specific scenario.
