### PR TITLE
Add Quill library

### DIFF
--- a/server/src/main/resources/libraries.json
+++ b/server/src/main/resources/libraries.json
@@ -295,6 +295,19 @@
         "compileTimeOnly": false
       },
       {
+        "name": "Quill",
+        "organization": "io.getquill",
+        "artifact": "quill-sql",
+        "doc": "http://getquill.io/",
+        "versions": {
+          "0.10.0": {
+            "scalaVersions": ["2.11"],
+            "extraDeps": []
+          }
+        },
+        "compileTimeOnly": false
+      },
+      {
         "name": "Rapture",
         "organization": "com.propensive",
         "artifact": "rapture",


### PR DESCRIPTION
This PR adds `quill-sql` to Scala fiddle. I've run it locally and it works with this example:

``` scala
// Start writing your ScalaFiddle code here
import io.getquill._

val ctx = new SqlMirrorContext[PostgresDialect, SnakeCase]

import ctx._

case class Person(name: String, age: Int)

val m = ctx.run(query[Person].filter(_.name == "John"))

println(m.string)
```

I've had to manually change the dom to access the library entry, though:

![](http://g.recordit.co/NKp7JrOK4U.gif)
