### PR TITLE
Add Apps-Scaripped (Scala Wrapper of Google Apps Scripts API)

### DIFF
--- a/server/src/main/resources/libraries.json
+++ b/server/src/main/resources/libraries.json
@@ -315,6 +315,19 @@
         "compileTimeOnly": false
       },
       {
+        "name": "Apps-Scaripped",
+        "organization": "com.crealytics",
+        "artifact": "apps-scaripped-api",
+        "doc": "https://github.com/crealytics/apps-scaripped",
+        "versions": {
+          "0.2.6": {
+            "scalaVersions": ["2.11"],
+            "extraDeps": []
+          }
+        },
+        "compileTimeOnly": false
+      },
+      {
         "name": "Java8 Time",
         "organization": "org.scala-js",
         "artifact": "scalajs-java-time",


### PR DESCRIPTION
Closes #36.
This PR adds [Apps-Scaripped](https://github.com/crealytics/apps-scaripped), a wrapper around the [Google Apps Script API](https://developers.google.com/apps-script/).
It cannot be directly executed inside ScalaFiddle, instead you can use the generated JS and paste or eval it in places where you can use ordinary Apps Scripts.
@ochrons One question regarding that: Is there a stable URL pattern that can be used to retrieve a non-wrapped version of the JS code?
I'll try to improve the README of Apps-Scaripped a little when I'm back from vacation, but in most parts is a rather simple wrapper with some added super-classes and nicer Scala-style iteration patterns.
