### PR TITLE
Add Each library

### DIFF
--- a/server/src/main/resources/libraries.json
+++ b/server/src/main/resources/libraries.json
@@ -104,6 +104,19 @@
         "compileTimeOnly": false
       },
       {
+        "name": "Each",
+        "organization": "com.thoughtworks.each",
+        "artifact": "each",
+        "doc": "ThoughtWorksInc/each",
+        "versions": {
+          "3.0.1": {
+            "scalaVersions": ["2.11"],
+            "extraDeps": []
+          }
+        },
+        "compileTimeOnly": false
+      },
+      {
         "name": "Shapeless",
         "organization": "com.chuusai",
         "artifact": "shapeless",


### PR DESCRIPTION
ThoughtWorks Each is a macro library that converts native imperative syntax to scalaz's monadic expression.

See https://github.com/ThoughtWorksInc/each
