### PR TITLE
Allow examples that require local storage

### DIFF
--- a/client/src/main/scala/scalafiddle/client/component/FiddleEditor.scala
+++ b/client/src/main/scala/scalafiddle/client/component/FiddleEditor.scala
@@ -123,7 +123,7 @@ object FiddleEditor {
                     width := "100%",
                     height := "100%",
                     frameBorder := "0",
-                    sandbox := "allow-scripts allow-popups allow-popups-to-escape-sandbox",
+                    sandbox := "allow-scripts allow-popups allow-popups-to-escape-sandbox allow-same-origin",
                     src := s"/resultframe?theme=light")
                 )
               case UserFiddleData(fiddles) =>


### PR DESCRIPTION
There are some examples like https://jsfiddle.net/yyx990803/zj8nh919/ , which uses local storage.

This PR will enable the feature.