### PR TITLE
Add 10.0.1 version for Binding.scala

### DIFF
--- a/server/src/main/resources/libraries.json
+++ b/server/src/main/resources/libraries.json
@@ -196,6 +196,15 @@
         "artifact": "binding",
         "doc": "ThoughtWorksInc/Binding.scala",
         "versions": {
+          "10.0.1": {
+            "scalaVersions": ["2.11"],
+            "extraDeps": [
+              "com.thoughtworks.binding %%% route % 10.0.1",
+              "com.thoughtworks.binding %%% dom % 10.0.1",
+              "com.thoughtworks.binding %%% futurebinding % 10.0.1",
+              "com.thoughtworks.binding %%% jspromisebinding % 10.0.1"
+            ]
+          },
           "9.0.3": {
             "scalaVersions": ["2.11"],
             "extraDeps": [

--- a/server/src/main/resources/libraries.json
+++ b/server/src/main/resources/libraries.json
@@ -205,6 +205,23 @@
               "com.thoughtworks.binding %%% jspromisebinding % 10.0.1"
             ]
           },
+          "10.0.0": {
+            "scalaVersions": ["2.11"],
+            "extraDeps": [
+              "com.thoughtworks.binding %%% route % 10.0.0",
+              "com.thoughtworks.binding %%% dom % 10.0.0",
+              "com.thoughtworks.binding %%% futurebinding % 10.0.0",
+              "com.thoughtworks.binding %%% jspromisebinding % 10.0.0"
+            ]
+          },
+          "9.0.4": {
+            "scalaVersions": ["2.11"],
+            "extraDeps": [
+              "com.thoughtworks.binding %%% dom % 9.0.4",
+              "com.thoughtworks.binding %%% futurebinding % 9.0.4",
+              "com.thoughtworks.binding %%% jspromisebinding % 9.0.4"
+            ]
+          },
           "9.0.3": {
             "scalaVersions": ["2.11"],
             "extraDeps": [

--- a/server/src/main/resources/libraries.json
+++ b/server/src/main/resources/libraries.json
@@ -197,7 +197,7 @@
         "doc": "ThoughtWorksInc/Binding.scala",
         "versions": {
           "10.0.1": {
-            "scalaVersions": ["2.10", "2.11", "2.12"],
+            "scalaVersions": ["2.11", "2.12"],
             "extraDeps": [
               "com.thoughtworks.binding %%% route % 10.0.1",
               "com.thoughtworks.binding %%% dom % 10.0.1",
@@ -206,7 +206,7 @@
             ]
           },
           "10.0.0": {
-            "scalaVersions": ["2.10", "2.11", "2.12"],
+            "scalaVersions": ["2.11", "2.12"],
             "extraDeps": [
               "com.thoughtworks.binding %%% route % 10.0.0",
               "com.thoughtworks.binding %%% dom % 10.0.0",
@@ -215,7 +215,7 @@
             ]
           },
           "9.0.4": {
-            "scalaVersions": ["2.10", "2.11", "2.12"],
+            "scalaVersions": ["2.11", "2.12"],
             "extraDeps": [
               "com.thoughtworks.binding %%% dom % 9.0.4",
               "com.thoughtworks.binding %%% futurebinding % 9.0.4",
@@ -223,7 +223,7 @@
             ]
           },
           "9.0.3": {
-            "scalaVersions": ["2.10", "2.11"],
+            "scalaVersions": ["2.11"],
             "extraDeps": [
               "com.thoughtworks.binding %%% dom % 9.0.3",
               "com.thoughtworks.binding %%% futurebinding % 9.0.3",
@@ -231,7 +231,7 @@
             ]
           },
           "9.0.2": {
-            "scalaVersions": ["2.10", "2.11"],
+            "scalaVersions": ["2.11"],
             "extraDeps": [
               "com.thoughtworks.binding %%% dom % 9.0.2",
               "com.thoughtworks.binding %%% futurebinding % 9.0.2",
@@ -239,7 +239,7 @@
             ]
           },
           "9.0.0": {
-            "scalaVersions": ["2.10", "2.11"],
+            "scalaVersions": ["2.11"],
             "extraDeps": [
               "com.thoughtworks.binding %%% dom % 9.0.0",
               "com.thoughtworks.binding %%% futurebinding % 9.0.0",

--- a/server/src/main/resources/libraries.json
+++ b/server/src/main/resources/libraries.json
@@ -197,7 +197,7 @@
         "doc": "ThoughtWorksInc/Binding.scala",
         "versions": {
           "10.0.1": {
-            "scalaVersions": ["2.11"],
+            "scalaVersions": ["2.10", "2.11", "2.12"],
             "extraDeps": [
               "com.thoughtworks.binding %%% route % 10.0.1",
               "com.thoughtworks.binding %%% dom % 10.0.1",
@@ -206,7 +206,7 @@
             ]
           },
           "10.0.0": {
-            "scalaVersions": ["2.11"],
+            "scalaVersions": ["2.10", "2.11", "2.12"],
             "extraDeps": [
               "com.thoughtworks.binding %%% route % 10.0.0",
               "com.thoughtworks.binding %%% dom % 10.0.0",
@@ -215,7 +215,7 @@
             ]
           },
           "9.0.4": {
-            "scalaVersions": ["2.11"],
+            "scalaVersions": ["2.10", "2.11", "2.12"],
             "extraDeps": [
               "com.thoughtworks.binding %%% dom % 9.0.4",
               "com.thoughtworks.binding %%% futurebinding % 9.0.4",
@@ -223,7 +223,7 @@
             ]
           },
           "9.0.3": {
-            "scalaVersions": ["2.11"],
+            "scalaVersions": ["2.10", "2.11"],
             "extraDeps": [
               "com.thoughtworks.binding %%% dom % 9.0.3",
               "com.thoughtworks.binding %%% futurebinding % 9.0.3",
@@ -231,7 +231,7 @@
             ]
           },
           "9.0.2": {
-            "scalaVersions": ["2.11"],
+            "scalaVersions": ["2.10", "2.11"],
             "extraDeps": [
               "com.thoughtworks.binding %%% dom % 9.0.2",
               "com.thoughtworks.binding %%% futurebinding % 9.0.2",
@@ -239,7 +239,7 @@
             ]
           },
           "9.0.0": {
-            "scalaVersions": ["2.11"],
+            "scalaVersions": ["2.10", "2.11"],
             "extraDeps": [
               "com.thoughtworks.binding %%% dom % 9.0.0",
               "com.thoughtworks.binding %%% futurebinding % 9.0.0",


### PR DESCRIPTION
Recently, Binding.scala 10.0 has been released:
https://github.com/ThoughtWorksInc/Binding.scala/releases/tag/v10.0.0
https://github.com/ThoughtWorksInc/Binding.scala/releases/tag/v10.0.1

@ochrons  Would you mind adding it to ScalaFiddle?