### PR TITLE
Update dependencies

### DIFF
--- a/client/src/main/scala/scalafiddle/client/component/FiddleEditor.scala
+++ b/client/src/main/scala/scalafiddle/client/component/FiddleEditor.scala
@@ -1,8 +1,8 @@
 package scalafiddle.client.component
 
-import diode.data.{Pot, Ready}
+import diode.data.Ready
 import diode.react.ModelProxy
-import diode.{Action, ModelR, ModelRO, NoAction}
+import diode._
 import japgolly.scalajs.react._
 import org.scalajs.dom
 import org.scalajs.dom.raw.{Event, HTMLElement, HTMLIFrameElement, MessageEvent}
@@ -11,7 +11,7 @@ import scala.concurrent.ExecutionContext.Implicits.{global => ecGlobal}
 import scala.concurrent.{Future, Promise}
 import scala.scalajs.js
 import scala.scalajs.js.Dynamic._
-import scala.scalajs.js.{JSON, Dynamic => Dyn}
+import scala.scalajs.js.{Dynamic => Dyn}
 import scala.util.Success
 import scalafiddle.client._
 import scalafiddle.shared._
@@ -30,7 +30,7 @@ object FiddleEditor {
     fiddleId: Option[FiddleId],
     outputData: ModelR[AppModel, OutputData],
     loginData: ModelR[AppModel, LoginData]) {
-    def dispatch = data.theDispatch
+    def dispatch[A: ActionType](a: A) = data.dispatchCB(a)
   }
 
   case class State(

--- a/client/src/main/scala/scalafiddle/client/component/Sidebar.scala
+++ b/client/src/main/scala/scalafiddle/client/component/Sidebar.scala
@@ -1,12 +1,12 @@
 package scalafiddle.client.component
 
-import diode.NoAction
+import diode.{Action, ActionType, NoAction}
 import diode.data.{Pot, Ready}
 import diode.react.ModelProxy
 import japgolly.scalajs.react._
 import org.scalajs.dom.raw.HTMLDivElement
-import scalajs.js
 
+import scalajs.js
 import scalafiddle.client._
 import scalafiddle.shared._
 
@@ -25,7 +25,7 @@ object Sidebar {
   case object AvailableLib extends LibMode
 
   case class Props(data: ModelProxy[FiddleData]) {
-    def dispatch = data.theDispatch
+    def dispatch[A: ActionType](a: A) = data.dispatchCB(a)
   }
 
   case class State(showAllVersions: Boolean)
@@ -103,7 +103,7 @@ object Sidebar {
       )
     }
 
-    def renderLibrary(lib: Library, mode: LibMode, dispatch: Any => Callback) = {
+    def renderLibrary(lib: Library, mode: LibMode, dispatch: Action => Callback) = {
       val (action, icon) = mode match {
         case SelectedLib => (DeselectLibrary(lib), i(cls := "remove red icon"))
         case AvailableLib => (SelectLibrary(lib), i(cls := "plus green icon"))

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -20,23 +20,23 @@ object Settings {
   /** Declare global dependency versions here to avoid mismatches in multi part dependencies */
   object versions {
     val scala = "2.11.8"
-    val scalatest = "3.0.0"
+    val scalatest = "3.0.1"
     val scalaDom = "0.9.1"
-    val scalajsReact = "0.11.1"
-    val scalaCSS = "0.4.1"
-    val autowire = "0.2.5"
+    val scalajsReact = "0.11.3"
+    val scalaCSS = "0.5.1"
+    val autowire = "0.2.6"
     val booPickle = "1.2.4"
-    val diode = "1.0.0"
+    val diode = "1.1.1"
     val uTest = "0.4.3"
-    val upickle = "0.3.8"
-    val slick = "3.1.0"
+    val upickle = "0.4.4"
+    val slick = "3.1.1"
     val silhouette = "4.0.0"
 
-    val jQuery = "3.0.0"
-    val semantic = "2.2.2"
-    val ace = "1.2.2"
+    val jQuery = "3.1.1"
+    val semantic = "2.2.7"
+    val ace = "1.2.3"
 
-    val react = "15.1.0"
+    val react = "15.4.2"
 
     val playScripts = "0.5.0"
   }
@@ -55,16 +55,16 @@ object Settings {
   val jvmDependencies = Def.setting(Seq(
     "com.typesafe.slick" %% "slick" % versions.slick,
     "com.typesafe.slick" %% "slick-hikaricp" % versions.slick,
-    "com.h2database" % "h2" % "1.4.190",
+    "com.h2database" % "h2" % "1.4.193",
     "org.postgresql" % "postgresql" % "9.4-1206-jdbc41",
     "com.mohiva" %% "play-silhouette" % versions.silhouette,
     "com.mohiva" %% "play-silhouette-password-bcrypt" % versions.silhouette,
     "com.mohiva" %% "play-silhouette-persistence" % versions.silhouette,
     "com.mohiva" %% "play-silhouette-crypto-jca" % versions.silhouette,
-    "net.codingwell" %% "scala-guice" % "4.0.1",
-    "com.iheart" %% "ficus" % "1.2.6",
+    "net.codingwell" %% "scala-guice" % "4.1.0",
+    "com.iheart" %% "ficus" % "1.4.0",
     "com.vmunier" %% "play-scalajs-scripts" % versions.playScripts,
-    "org.webjars" % "font-awesome" % "4.6.3" % Provided,
+    "org.webjars" % "font-awesome" % "4.7.0" % Provided,
     "org.webjars" % "Semantic-UI" % versions.semantic % Provided,
     "org.webjars" % "ace" % versions.ace % Provided
   ))
@@ -74,9 +74,9 @@ object Settings {
     "com.github.japgolly.scalajs-react" %%% "core" % versions.scalajsReact,
     "com.github.japgolly.scalajs-react" %%% "extra" % versions.scalajsReact,
     "com.github.japgolly.scalacss" %%% "ext-react" % versions.scalaCSS,
-    "me.chrons" %%% "diode" % versions.diode,
-    "me.chrons" %%% "diode-react" % versions.diode,
-    "com.github.marklister" %%% "base64" % "0.2.2",
+    "io.suzaku" %%% "diode" % versions.diode,
+    "io.suzaku" %%% "diode-react" % versions.diode,
+    "com.github.marklister" %%% "base64" % "0.2.3",
     "org.scala-js" %%% "scalajs-dom" % versions.scalaDom
   ))
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,3 +17,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.6")
+
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "typesafe" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
 
@@ -8,7 +8,7 @@ addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.4.0")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.7.1")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.4")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.12")
 
 addSbtPlugin("com.vmunier" % "sbt-play-scalajs" % "0.3.0")
 


### PR DESCRIPTION
- added https://github.com/rtimush/sbt-updates plugin to easily check available dependency updates with `sbt dependencyUpdates`
- updated sbt to version `0.13.13`
- updated dependencies

Changes to `FiddleEditor.scala` and `Sidebar.scala` are caused by https://github.com/suzaku-io/diode/commit/4dc051281844b1df75847586fbc32a5d8131e838 commit.
