### PR TITLE
Optimize layout for small screen size

### DIFF
--- a/client/src/main/scala/scalafiddle/client/component/Sidebar.scala
+++ b/client/src/main/scala/scalafiddle/client/component/Sidebar.scala
@@ -14,6 +14,7 @@ object Sidebar {
 
   import SemanticUI._
 
+  private var sideBarRef: HTMLDivElement = _
   private var accordionRef: HTMLDivElement = _
 
   sealed trait LibMode
@@ -26,7 +27,7 @@ object Sidebar {
     def dispatch(a: Action) = data.dispatchCB(a)
   }
 
-  case class State(showAllVersions: Boolean)
+  case class State(showAllVersions: Boolean, isOpen: Boolean = true)
 
   case class Backend($ : BackendScope[Props, State]) {
 
@@ -53,7 +54,7 @@ object Sidebar {
         case _ =>
           ("Anonymous", "/assets/images/anon.png")
       }
-      div(cls := "sidebar")(
+      div.ref(sideBarRef = _)(cls := "sidebar")(
         div.ref(accordionRef = _)(cls := "ui accordion")(
           div(cls := "title large active", "Info", i(cls := "icon dropdown")),
           div(cls := "content active")(
@@ -134,6 +135,14 @@ object Sidebar {
               )
             )
           )
+        ),
+        div(cls := "bottom")(
+          div(cls := "ui basic button toggle", onClick ==> { (e: ReactEventFromHtml) =>
+            Callback {
+              e.target.textContent = if (state.isOpen) "Show" else "Hide"
+              sideBarRef.classList.toggle("folded")
+            } >> $.modState(s => s.copy(isOpen = !state.isOpen))
+          })("Hide")
         )
       )
     }

--- a/server/src/main/assets/stylesheets/main.less
+++ b/server/src/main/assets/stylesheets/main.less
@@ -1,6 +1,8 @@
 @import (inline) "lib/Semantic-UI/semantic.min.css";
 @import "lib/font-awesome/less/font-awesome.less";
 
+@mobile: ~"(max-width: 1280px)";
+
 html,
 body,
 .full-screen {
@@ -99,8 +101,28 @@ body {
       .column;
       width: 250px;
       border-right: solid 1px #eaeaef;
+
       > div {
         padding: 0 10px;
+      }
+
+      > .bottom {
+        padding: 0 10px;
+        margin-top: auto;
+
+        > .toggle {
+          text-align: center;
+          margin-bottom: 10px;
+          width: 100%;
+        }
+      }
+
+      &.folded {
+        width: 100px;
+
+        > .accordion {
+          display: none;
+        }
       }
     }
 
@@ -109,14 +131,29 @@ body {
       .stretchy;
       flex-direction: row;
 
+      @media @mobile {
+        flex-direction: column;
+      }
+
       > .editor {
         flex: 1;
         position: relative;
         border-right: solid 1px #eaeaef;
+
+        @media @mobile {
+          border-bottom: solid 1px #eaeaef;
+        }
+
         > #editor {
           width: 100%;
           height: 100%;
           position: absolute;
+
+          > .ace_gutter {
+            @media @mobile {
+              display: none;
+            }
+          }
         }
       }
 


### PR DESCRIPTION
Current look:
![before_](https://user-images.githubusercontent.com/7420409/30319127-b8f6a4fa-97b7-11e7-91e9-ca1dfda402b7.png)

Proposed look (activated on screen width < 1280, vertical layout, no line numbers, sidebar can be hidden):
![after_](https://user-images.githubusercontent.com/7420409/30319143-c7a51b4e-97b7-11e7-8ade-0aba8fda31e3.png)
