### PR TITLE
Configure Scala.js source mapping

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,3 +21,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.6")
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.14")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")
+
+addSbtPlugin("com.thoughtworks.sbt-scala-js-map" % "sbt-scala-js-map" % "2.0.0")


### PR DESCRIPTION
This plugin will enable source mapping, which will help contributors of ScalaFiddle to debug.