### PR TITLE
Reverse chronological order for my fiddles

### DIFF
--- a/client/src/main/scala/scalafiddle/client/component/FiddleEditor.scala
+++ b/client/src/main/scala/scalafiddle/client/component/FiddleEditor.scala
@@ -171,7 +171,7 @@ object FiddleEditor {
                           )
                         ),
                         tbody(
-                          fiddles.toTagMod {
+                          fiddles.sortBy(-_.updated).toTagMod {
                             fiddle =>
                               def fLink(version: Int)(content: TagMod*) =
                                 a(href := s"/sf/${fiddle.id}/$version")(content: _*)


### PR DESCRIPTION
Starting to save bunch of fiddles and finding it hard to see my latest saved fiddle, I hope this help.

Better solution would be to allow the fiddle table to be sorted with different sort on headers but I have no clue how.