### PR TITLE
Wrap checkbox in label to associate them together

### DIFF
--- a/client/src/main/scala/scalafiddle/client/component/FiddleEditor.scala
+++ b/client/src/main/scala/scalafiddle/client/component/FiddleEditor.scala
@@ -124,8 +124,10 @@ object FiddleEditor {
                     div(cls := "divider"),
                     div(cls := "ui input")(
                       div(cls := "ui checkbox")(
-                        input.checkbox(checked := state.showTemplate, onChange --> switchTemplate),
-                        label("Show template")
+                        label(
+                          "Show template",
+                          input.checkbox(checked := state.showTemplate, onChange --> switchTemplate)
+                        )
                       )
                     )
                 ))


### PR DESCRIPTION
This should fix the issue #78 where clicking the label doesn't click the checkbox.

This is different than using ids/for attributes, where its simpler to wrap `<label><checkbox/></label>` around the checkbox.

Might want to double-check on your side, as I had problems running `sbt run` to test locally.