### PR TITLE
Add support for fiddles using Scala.js 1.0.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,21 @@ jdk:
 - openjdk8
 script:
 - sbt ++$TRAVIS_SCALA_VERSION server/test client/test
-# Tricks to avoid unnecessary cache updates, from
-# http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html
-- find $HOME/.sbt -name "*.lock" | xargs rm
-- find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
 cache:
   directories:
+    - $HOME/.cache/coursier
     - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot/
+    - $HOME/.sbt
 install:
   - . $HOME/.nvm/nvm.sh
   - nvm install stable
   - nvm use stable
   - npm install
   - npm install jsdom@9.12.0
+
+# Tricks to avoid unnecessary cache updates, from
+# https://www.scala-sbt.org/1.x/docs/Travis-CI-with-sbt.html#Caching
+before_cache:
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt -name "*.lock" -print -delete

--- a/client/src/main/scala/scalafiddle/client/CompilerHandler.scala
+++ b/client/src/main/scala/scalafiddle/client/CompilerHandler.scala
@@ -1,5 +1,7 @@
 package scalafiddle.client
 
+import java.nio.charset.StandardCharsets
+
 import autowire._
 import diode._
 import org.scalajs.dom
@@ -7,7 +9,6 @@ import org.scalajs.dom.ext.Ajax
 import upickle.default._
 
 import scala.scalajs.js
-import scala.scalajs.niocharset.StandardCharsets
 import scala.concurrent.ExecutionContext.Implicits.global
 import scalafiddle.shared.{Api, FiddleVersions}
 

--- a/client/src/main/scala/scalafiddle/client/FiddleHandler.scala
+++ b/client/src/main/scala/scalafiddle/client/FiddleHandler.scala
@@ -15,6 +15,8 @@ case class DeselectLibrary(lib: Library) extends Action
 
 case class SelectScalaVersion(version: String) extends Action
 
+case class SelectScalaJSVersion(version: String) extends Action
+
 case class UpdateInfo(name: String, description: String) extends Action
 
 case class UpdateSource(source: String) extends Action
@@ -42,6 +44,9 @@ class FiddleHandler[M](modelRW: ModelRW[M, FiddleData], fidRW: ModelRW[M, Option
 
     case SelectScalaVersion(version) =>
       updated(value.copy(scalaVersion = version))
+
+    case SelectScalaJSVersion(version) =>
+      updated(value.copy(scalaJSVersion = version))
 
     case UpdateInfo(name, description) =>
       updated(value.copy(name = name, description = description))

--- a/client/src/main/scala/scalafiddle/client/Utils.scala
+++ b/client/src/main/scala/scalafiddle/client/Utils.scala
@@ -76,9 +76,10 @@ object SHA1 extends js.Object {
 @js.native
 @JSGlobal("ScalaFiddleConfig")
 object ScalaFiddleConfig extends js.Object {
-  val compilerURL: String             = js.native
-  val helpURL: String                 = js.native
-  val scalaVersions: js.Array[String] = js.native
+  val compilerURL: String               = js.native
+  val helpURL: String                   = js.native
+  val scalaVersions: js.Array[String]   = js.native
+  val scalaJSVersions: js.Array[String] = js.native
 }
 
 @js.native

--- a/client/src/main/scala/scalafiddle/client/component/Sidebar.scala
+++ b/client/src/main/scala/scalafiddle/client/component/Sidebar.scala
@@ -37,6 +37,7 @@ object Sidebar {
       val availableVersions = fd.available
         .filterNot(lib => fd.libraries.exists(_.name == lib.name))
         .filter(lib => lib.scalaVersions.contains(fd.scalaVersion))
+        .filter(lib => lib.scalaJSVersions.contains(fd.scalaJSVersion))
 
       // hide alternative versions, if requested
       val available =
@@ -135,6 +136,31 @@ object Sidebar {
                           }
                         ),
                         label(version)
+                      )
+                    )
+                  }
+                )
+              )
+            ),
+            div(cls := "ui grid")(
+              div(cls := "eight wide column")(
+                h4("Scala.js version")
+              ),
+              div(cls := "eight wide column right aligned")(
+                div(cls := "grouped fields")(
+                  ScalaFiddleConfig.scalaJSVersions.toTagMod { version =>
+                    div(cls := "field")(
+                      div(cls := "ui radio checkbox")(
+                        input.radio(
+                          name := "scalajsversion",
+                          value := version,
+                          checked := props.data().scalaJSVersion == version,
+                          onChange ==> { (e: ReactEventFromInput) =>
+                            val newVersion = e.currentTarget.value
+                            props.dispatch(SelectScalaJSVersion(newVersion))
+                          }
+                        ),
+                        label(version + ".x")
                       )
                     )
                   }

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -57,6 +57,9 @@ scalafiddle {
   scalaVersions = ["2.11", "2.12"]
   defaultScalaVersion = "2.12"
 
+  scalaJSVersions = ["0.6", "1"]
+  defaultScalaJSVersion = "0.6"
+
   refreshLibraries = 300
   refreshLibraries = ${?SCALAFIDDLE_REFRESH_LIBRARIES}
 

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -58,7 +58,7 @@ scalafiddle {
   defaultScalaVersion = "2.12"
 
   scalaJSVersions = ["0.6", "1"]
-  defaultScalaJSVersion = "0.6"
+  defaultScalaJSVersion = "1"
 
   refreshLibraries = 300
   refreshLibraries = ${?SCALAFIDDLE_REFRESH_LIBRARIES}

--- a/server/src/main/scala/scalafiddle/server/Librarian.scala
+++ b/server/src/main/scala/scalafiddle/server/Librarian.scala
@@ -12,6 +12,7 @@ class Librarian(libSource: () => BufferedSource) {
   case class LibraryVersion(
       version: String,
       scalaVersions: Seq[String],
+      scalaJSVersions: Seq[String],
       extraDeps: Seq[String],
       organization: Option[String],
       artifact: Option[String],
@@ -25,6 +26,7 @@ class Librarian(libSource: () => BufferedSource) {
       LibraryVersion(
         readJs[String](values("version")),
         readJs[Seq[String]](values("scalaVersions")),
+        values.get("scalaJSVersions").map(readJs[Seq[String]]).getOrElse(Seq("0.6")),
         readJs[Seq[String]](values.getOrElse("extraDeps", Js.Arr())),
         values.get("organization").map(readJs[String]),
         values.get("artifact").map(readJs[String]),
@@ -80,6 +82,7 @@ class Librarian(libSource: () => BufferedSource) {
         versionDef.version,
         lib.compileTimeOnly,
         versionDef.scalaVersions,
+        versionDef.scalaJSVersions,
         versionDef.extraDeps,
         f"$idx%02d:${group.group}",
         createDocURL(versionDef.doc.getOrElse(lib.doc)),

--- a/server/src/main/scala/scalafiddle/server/Persistence.scala
+++ b/server/src/main/scala/scalafiddle/server/Persistence.scala
@@ -87,6 +87,7 @@ class Persistence @Inject() (config: Configuration) extends Actor with ActorLogg
         fiddle.sourceCode,
         fiddle.libraries.map(Library.stringify).toList,
         fiddle.scalaVersion,
+        fiddle.scalaJSVersion,
         user
       )
       runAndReply(dal.insertFiddle(newFiddle))(r => Success(FiddleId(id, 0))) pipeTo sender()
@@ -101,6 +102,7 @@ class Persistence @Inject() (config: Configuration) extends Actor with ActorLogg
         fiddle.sourceCode,
         fiddle.libraries.map(Library.stringify).toList,
         fiddle.scalaVersion,
+        fiddle.scalaJSVersion,
         user,
         Some(s"$id/$version")
       )
@@ -142,6 +144,7 @@ class Persistence @Inject() (config: Configuration) extends Actor with ActorLogg
               fiddle.sourceCode,
               fiddle.libraries.map(Library.stringify).toList,
               fiddle.scalaVersion,
+              fiddle.scalaJSVersion,
               latest.user,
               Some(s"${latest.id}/${latest.version}")
             )

--- a/server/src/main/scala/scalafiddle/server/dao/FiddleDAO.scala
+++ b/server/src/main/scala/scalafiddle/server/dao/FiddleDAO.scala
@@ -8,6 +8,7 @@ case class Fiddle(
     sourceCode: String,
     libraries: List[String],
     scalaVersion: String,
+    scalaJSVersion: String,
     user: String,
     parent: Option[String] = None,
     created: Long = System.currentTimeMillis(),
@@ -24,21 +25,22 @@ trait FiddleDAO { self: DriverComponent =>
   )
 
   class Fiddles(tag: Tag) extends Table[Fiddle](tag, "fiddle") {
-    def id           = column[String]("id")
-    def version      = column[Int]("version")
-    def name         = column[String]("name")
-    def description  = column[String]("description")
-    def sourceCode   = column[String]("sourcecode")
-    def libraries    = column[List[String]]("libraries")
-    def scalaVersion = column[String]("scala_version")
-    def user         = column[String]("user")
-    def parent       = column[Option[String]]("parent")
-    def created      = column[Long]("created")
-    def removed      = column[Boolean]("removed")
-    def pk           = primaryKey("pk_fiddle", (id, version))
+    def id             = column[String]("id")
+    def version        = column[Int]("version")
+    def name           = column[String]("name")
+    def description    = column[String]("description")
+    def sourceCode     = column[String]("sourcecode")
+    def libraries      = column[List[String]]("libraries")
+    def scalaVersion   = column[String]("scala_version")
+    def scalaJSVersion = column[String]("scalajs_version")
+    def user           = column[String]("user")
+    def parent         = column[Option[String]]("parent")
+    def created        = column[Long]("created")
+    def removed        = column[Boolean]("removed")
+    def pk             = primaryKey("pk_fiddle", (id, version))
 
     def * =
-      (id, version, name, description, sourceCode, libraries, scalaVersion, user, parent, created, removed) <> (Fiddle.tupled, Fiddle.unapply)
+      (id, version, name, description, sourceCode, libraries, scalaVersion, scalaJSVersion, user, parent, created, removed) <> (Fiddle.tupled, Fiddle.unapply)
   }
 
   val fiddles = TableQuery[Fiddles]

--- a/server/src/main/twirl/views/index.scala.html
+++ b/server/src/main/twirl/views/index.scala.html
@@ -43,6 +43,7 @@
           cfg.compilerURL = "@config.get[String]("scalafiddle.compilerURL")";
           cfg.helpURL = "@config.get[String]("scalafiddle.helpURL")";
           cfg.scalaVersions = @Html(config.get[Seq[String]]("scalafiddle.scalaVersions").mkString("[\"","\",\"","\"]"));
+          cfg.scalaJSVersions = @Html(config.get[Seq[String]]("scalafiddle.scalaJSVersions").mkString("[\"","\",\"","\"]"));
           window.ScalaFiddleConfig = cfg;
           window.ScalaFiddleData = @Html(fiddleData);
         </script>

--- a/server/src/main/twirl/views/resultframe.scala.html
+++ b/server/src/main/twirl/views/resultframe.scala.html
@@ -56,7 +56,7 @@
                             loads.then(function() {
                                 try {
                                     eval(msg.data.code);
-                                    eval("var sf = ScalaFiddle;if(typeof sf === 'function') { if(typeof sf().main === 'function') sf().main() } else if(typeof sf.main === 'function') sf.main();");
+                                    eval("if(typeof ScalaFiddle !== 'undefined') { var sf = ScalaFiddle;if(typeof sf === 'function') { if(typeof sf().main === 'function') sf().main() } else if(typeof sf.main === 'function') sf.main(); }");
                                 } catch(ex) {
                                     result.insertAdjacentHTML('beforeend', '<pre class="error">ERROR: ' + ex.message + '\n' + ex.stack + '</pre>')
                                 } finally {

--- a/shared/src/main/scala/scalafiddle/shared/FiddleData.scala
+++ b/shared/src/main/scala/scalafiddle/shared/FiddleData.scala
@@ -11,6 +11,7 @@ case class Library(
     version: String,
     compileTimeOnly: Boolean,
     scalaVersions: Seq[String],
+    scalaJSVersions: Seq[String],
     extraDeps: Seq[String],
     group: String,
     docUrl: String,
@@ -32,6 +33,7 @@ case class FiddleData(
     libraries: Seq[Library],
     available: Seq[Library],
     scalaVersion: String,
+    scalaJSVersion: String,
     author: Option[UserInfo],
     modified: Long
 )


### PR DESCRIPTION
This adds a new column `scalajs_version` in the `Fiddle` table.
The correct value for existing values should be `0.6`.

This PR goes together with https://github.com/scalafiddle/scalafiddle-core/pull/45 and https://github.com/scalafiddle/scalafiddle-io/pull/45.